### PR TITLE
auditfile content only

### DIFF
--- a/changelog/@unreleased/pr-6.v2.yml
+++ b/changelog/@unreleased/pr-6.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use 'content' only for auditfile, remove 'path' option.
+  links:
+  - https://github.com/palantir/terraform-provider-tenablesc/pull/6

--- a/docs/resources/auditfile.md
+++ b/docs/resources/auditfile.md
@@ -17,18 +17,16 @@ Create and manage Audit Files.
 
 ### Required
 
+- `content` (String) Audit file content
 - `name` (String) Audit file Name as presented in SC
 
 ### Optional
 
-- `content` (String) Audit file content inline - only one of content or path may be provided
 - `description` (String) Audit File description
-- `path` (String) Path to audit file on disk - only one of content or path may be provided
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `sc_filename` (String) Filename of audit file as stored in SC
-- `sha256_sum` (String) sha256 checksum of audit file as stored in SC
 
 

--- a/internal/provider/descriptions.go
+++ b/internal/provider/descriptions.go
@@ -93,10 +93,8 @@ Requires Administrator (org=0) credentials.`
 	descriptionAssetType            = `Asset type - may be 'dnsname' or 'static'`
 	descriptionAssetValues          = `Asset values - must be either DNS names or IPs based on type of asset.`
 
-	descriptionAuditFilePath       = `Path to audit file on disk - only one of content or path may be provided`
-	descriptionAuditFileContent    = `Audit file content inline - only one of content or path may be provided`
+	descriptionAuditFileContent    = `Audit file content`
 	descriptionAuditFileSCFilename = `Filename of audit file as stored in SC`
-	descriptionAuditFileSHA256Sum  = `sha256 checksum of audit file as stored in SC`
 
 	descriptionRiskRuleHostType  = `Host Type may be 'all', 'ip', or 'asset'`
 	descriptionRiskRuleHostValue = `A list of values depending on the host type.

--- a/internal/provider/resource_auditfile.go
+++ b/internal/provider/resource_auditfile.go
@@ -16,9 +16,6 @@ package provider
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"io/ioutil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -50,72 +47,30 @@ func ResourceAuditFile() *schema.Resource {
 				Optional:    true,
 				Default:     descriptionDefaultDescriptionValue,
 			},
-			"path": {
-				Type:        schema.TypeString,
-				Description: descriptionAuditFilePath,
-				Optional:    true,
-			},
 			"content": {
 				Type:        schema.TypeString,
 				Description: descriptionAuditFileContent,
-				Optional:    true,
+				Required:    true,
 			},
 			"sc_filename": {
 				Type:        schema.TypeString,
 				Description: descriptionAuditFileSCFilename,
 				Computed:    true,
 			},
-			"sha256_sum": {
-				Type:        schema.TypeString,
-				Description: descriptionAuditFileSHA256Sum,
-				Computed:    true,
-				ForceNew:    true,
-			},
 		},
 	}
 }
 
-func sha256sum(bytes []byte) string {
-	shabuilder := sha256.New()
-	shabuilder.Write(bytes)
-	sum := hex.EncodeToString(shabuilder.Sum(nil))
-
-	return sum
-}
-func readLocalFile(path string) (content []byte, sum string, err error) {
-	content, err = ioutil.ReadFile(path)
-	if err != nil {
-		return
-	}
-
-	sum = sha256sum(content)
-	return
-}
 func resourceAuditFileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	Logf(logTrace, "start of function")
 	sc := m.(*tenablesc.Client)
 
 	// upload the audit file if we need to
 	var content []byte
-	var sum string
 	var err error
-	var ok bool
-	var path string
 
 	name := d.Get("name").(string)
-	if path, ok = d.Get("path").(string); ok && path != "" {
-		content, sum, err = readLocalFile(path)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	} else if content, ok = d.Get("content").([]byte); ok && len(content) > 0 {
-		sum = sha256sum(content)
-	} else {
-		return diag.Diagnostics{{
-			Severity: diag.Error,
-			Summary:  "Audit file must either specify path or content.",
-		}}
-	}
+	content = d.Get("content").([]byte)
 
 	file, err := sc.UploadFileFromString(string(content), name, "")
 	if err != nil {
@@ -124,7 +79,6 @@ func resourceAuditFileCreate(ctx context.Context, d *schema.ResourceData, m inte
 	}
 
 	d.Set("sc_filename", file.Filename)
-	d.Set("sha256_sum", sum)
 
 	response, err := sc.CreateAuditFile(buildAuditFileInput(d))
 	if err != nil {
@@ -141,13 +95,6 @@ func resourceAuditFileCreate(ctx context.Context, d *schema.ResourceData, m inte
 func resourceAuditFileRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	Logf(logTrace, "start of function")
 	sc := m.(*tenablesc.Client)
-
-	path := d.Get("path").(string)
-	_, sum, err := readLocalFile(path)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	d.Set("sha256_sum", sum)
 
 	auditFile, err := sc.GetAuditFile(d.Id())
 	if err != nil {


### PR DESCRIPTION
Using 'content' as a full-text field is strictly better for diffing and lets folks use the file() function for
import from disk. It's just a better abstraction.