### PR TITLE
Update generate command to provider provider name

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 
 // Run the docs generation tool, check its repository for more information on how it works and how docs
 // can be customized.
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name terraform-provider-tenablesc
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{


### PR DESCRIPTION
by default provider name is intuited from the base directory name of the package; automated PRs are producing unexpected diffs due to runtime directories and failing.

This should mitigate.