### PR TITLE
Correct repository organization association

### DIFF
--- a/changelog/@unreleased/pr-14.v2.yml
+++ b/changelog/@unreleased/pr-14.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correct typo in repository organization association
+  links:
+  - https://github.com/palantir/terraform-provider-tenablesc/pull/14

--- a/internal/provider/resource_repository_organization_association.go
+++ b/internal/provider/resource_repository_organization_association.go
@@ -108,7 +108,7 @@ func resourceRepositoryOrganizationAssociationRead(ctx context.Context, d *schem
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		org["org_id"] = int(orgIDInt)
+		org["organization_id"] = int(orgIDInt)
 		org["group_assignment"] = ro.GroupAssign
 
 		organizations = append(organizations, org)
@@ -155,7 +155,7 @@ func buildRepositoryOrganizationAssociationInputs(d *schema.ResourceData) (*tena
 	for _, org := range organizations {
 		org := org.(map[string]interface{})
 
-		id, ok := org["org_id"]
+		id, ok := org["organization_id"]
 		if !ok {
 			return nil, fmt.Errorf("got null organization id")
 		}


### PR DESCRIPTION
Typo from conversion, internal fieldname references for 'org_id' should be 'organization_id'