### PR TITLE
allow configuring plugin family's state for Scan policy resources

### DIFF
--- a/changelog/@unreleased/pr-64.v2.yml
+++ b/changelog/@unreleased/pr-64.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: allow configuring plugin family's state for Scan policy resources
+  links:
+  - https://github.com/palantir/terraform-provider-tenablesc/pull/64

--- a/docs/resources/scan_policy.md
+++ b/docs/resources/scan_policy.md
@@ -55,6 +55,7 @@ resource "sc_scan_policy" "vulnerability_scan_port22" {
 - `audit_file_id` (String) Audit File ID
 - `description` (String) Scan Policy description
 - `families` (Set of String) Plugin Families to include in scan
+- `families_state` (String) Plugin Families state to include in scan. Must be set to 'unlocked' for Tenable.SC 6x
 - `preferences` (Map of String) Key-value map of preferences to set and their values. Refer to documentation and browser developer tools to get preference names
 - `tag` (String) Tag for scan policy
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0
-	github.com/palantir/tenablesc-client v0.2.0
+	github.com/palantir/tenablesc-client v0.10.0
 	inet.af/netaddr v0.0.0-20220811202034-502d2d690317
 )
 

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/palantir/tenablesc-client v0.2.0 h1:s/ED/5j/1DQcCXhauxWBtXpHL4wNtX6srdFHhMhZm74=
-github.com/palantir/tenablesc-client v0.2.0/go.mod h1:xFvQJsr2r8rvL6mT2z0WOnes6Q1YeHhmjrnBnPGjp7o=
+github.com/palantir/tenablesc-client v0.10.0 h1:8LmUN1tW0ghwtJaz9UVJGaJ39PNXWeWZi58o3tOvOi0=
+github.com/palantir/tenablesc-client v0.10.0/go.mod h1:8tzZFHm1fvpsePPMFtbf23qhqyIolyveQD1lZZ/gCo8=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -203,7 +203,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/descriptions.go
+++ b/internal/provider/descriptions.go
@@ -136,9 +136,10 @@ Requires Administrator (org=0) credentials.`
  * fullAccess
  * partial`
 
-	descriptionScanPolicyPreferences = `Key-value map of preferences to set and their values. Refer to documentation and browser developer tools to get preference names`
-	descriptionScanPolicyFamilies    = `Plugin Families to include in scan`
-	descriptionScanPolicyTag         = `Tag for scan policy`
+	descriptionScanPolicyPreferences   = `Key-value map of preferences to set and their values. Refer to documentation and browser developer tools to get preference names`
+	descriptionScanPolicyFamilies      = `Plugin Families to include in scan`
+	descriptionScanPolicyFamiliesState = `Plugin Families state to include in scan. Must be set to 'unlocked' for Tenable.SC 6x`
+	descriptionScanPolicyTag           = `Tag for scan policy`
 
 	descriptionScanZoneCIDRs = `CIDR blocks included in scan zone`
 )

--- a/internal/provider/resource_scan_policy.go
+++ b/internal/provider/resource_scan_policy.go
@@ -71,6 +71,12 @@ func ResourceScanPolicy() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"families_state": {
+				Type:        schema.TypeString,
+				Description: descriptionScanPolicyFamiliesState,
+				Optional:    true,
+				Default:     "",
+			},
 			"tag": {
 				Type:        schema.TypeString,
 				Description: descriptionScanPolicyTag,
@@ -224,6 +230,7 @@ func buildScanPolicyInputs(d *schema.ResourceData) (*tenablesc.ScanPolicy, error
 	policyTemplateID := d.Get("policy_template_id").(string)
 	auditFileID := d.Get("audit_file_id").(string)
 	families := d.Get("families").(*schema.Set).List()
+	familiesState := d.Get("families_state").(string)
 	tag := d.Get("tag").(string)
 
 	// To identify what to remove from prefs, look at what's in state vs what we're
@@ -267,7 +274,7 @@ func buildScanPolicyInputs(d *schema.ResourceData) (*tenablesc.ScanPolicy, error
 
 	var famInput []tenablesc.ScanPolicyFamilies
 	for _, family := range families {
-		famInput = append(famInput, tenablesc.ScanPolicyFamilies{ID: family.(string)})
+		famInput = append(famInput, tenablesc.ScanPolicyFamilies{ID: family.(string), State: familiesState})
 	}
 	if len(famInput) > 0 {
 		spInput.Families = famInput

--- a/vendor/github.com/palantir/tenablesc-client/tenablesc/base.go
+++ b/vendor/github.com/palantir/tenablesc-client/tenablesc/base.go
@@ -10,7 +10,8 @@ import (
 // Common structures used throughout the Tenable API.
 
 // BaseInfo is used in the API to refer to related objects;
-//   For input, only the ID is needed; responses will include name and description.
+//
+//	For input, only the ID is needed; responses will include name and description.
 type BaseInfo struct {
 	ID          ProbablyString `json:"id,omitempty"`
 	Name        string         `json:"name,omitempty"`
@@ -18,9 +19,11 @@ type BaseInfo struct {
 }
 
 // UserInfo is used inb the API to refer to users.
-//   For input, only the ID is needed; responses will include remaining fields.
+//
+//	For input, only the ID is needed; responses will include remaining fields.
 type UserInfo struct {
 	ID        ProbablyString `json:"id,omitempty"`
+	UUID      string         `json:"uuid,omitempty"`
 	Username  string         `json:"username,omitempty"`
 	Firstname string         `json:"firstname,omitempty"`
 	Lastname  string         `json:"lastname,omitempty"`
@@ -47,10 +50,11 @@ func ToFakeBool(b bool) FakeBool {
 }
 
 // ProbablyString is used for most ID fields in the API;
-//  the SC API generally returns positive IDs as strings, but
-//  -1 and sometimes 0 are returned numerically.
-//  Since the API _accepts_ strings in those locations always, we only need to handle
-//  the output from calls.
+//
+//	the SC API generally returns positive IDs as strings, but
+//	-1 and sometimes 0 are returned numerically.
+//	Since the API _accepts_ strings in those locations always, we only need to handle
+//	the output from calls.
 type ProbablyString string
 
 func (p *ProbablyString) UnmarshalJSON(data []byte) error {
@@ -73,8 +77,9 @@ func (p *ProbablyString) UnmarshalJSON(data []byte) error {
 }
 
 // UnixEpochStringTime would ideally be time.Time, but partial-unmarshalling
-//  every single place we use a timestamp to do that conversion would be somewhat excruciating.
-//  So this is the compromise.
+//
+//	every single place we use a timestamp to do that conversion would be somewhat excruciating.
+//	So this is the compromise.
 type UnixEpochStringTime string
 
 func (s UnixEpochStringTime) ToDateTime() (time.Time, error) {

--- a/vendor/github.com/palantir/tenablesc-client/tenablesc/credential.go
+++ b/vendor/github.com/palantir/tenablesc-client/tenablesc/credential.go
@@ -7,7 +7,7 @@ import (
 const credentialEndpoint = "/credential"
 
 // Credential is massively pared back from the possible types in https://docs.tenable.com/tenablesc/api/Credential.htm
-// This is not wired to directly manage credentials, only to find them.
+// This is not wired to directly manage credentials, only to find and delete them.
 type Credential struct {
 	BaseInfo
 	Type      string   `json:"type"`
@@ -51,6 +51,128 @@ func (c *Client) GetCredential(id string) (*Credential, error) {
 
 	if _, err := c.getResource(fmt.Sprintf("%s/%s", credentialEndpoint, id), resp); err != nil {
 		return nil, fmt.Errorf("failed to get credential id %s: %w", id, err)
+	}
+
+	return resp, nil
+}
+
+func (c *Client) DeleteCredential(id string) error {
+	if _, err := c.deleteResource(fmt.Sprintf("%s/%s", credentialEndpoint, id), nil, nil); err != nil {
+		return fmt.Errorf("unable to delete credential with id %s: %w", id, err)
+	}
+
+	return nil
+}
+
+// SSHCertificateCredentialUpload https://docs.tenable.com/tenablesc/api/Credential.htm#credential_POST
+type SSHCertificateCredentialUpload struct {
+	BaseInfo
+	Tags                string `json:"tags"`
+	Type                string `json:"type"`
+	Username            string `json:"username"`
+	AuthType            string `json:"authType"`
+	PublicKey           string `json:"publicKey"`
+	PrivateKey          string `json:"privateKey"`
+	PrivilegeEscalation string `json:"privilegeEscalation"`
+}
+
+// handleSSHCertCredFileUpload takes a key as a string and uploads it as a new file to tenable.sc.
+// it returns the name of the fie that it is stored as on tenable.sc.
+// this file name is used as a reference when creating or modifying SSH certificate credentials
+func (c *Client) handleSSHCertCredFileUpload(key string) (string, error) {
+	keyFile, err := c.UploadFileFromString(key, "key", "")
+	if err != nil {
+		return "", fmt.Errorf("unable to upload key file: %w", err)
+	}
+	return keyFile.Filename, nil
+}
+
+// DBCredentialUpload https://docs.tenable.com/tenablesc/api/Credential.htm#credential_POST
+type DBCredentialUpload struct {
+	BaseInfo
+	Tags     string `json:"tags"`
+	Type     string `json:"type"`
+	AuthType string `json:"authType"`
+	Login    string `json:"login"`
+	Password string `json:"password"`
+	SID      string `json:"sid"`
+	DBType   string `json:"dbType"`
+	Port     string `json:"port"`
+}
+
+const (
+	postgresDBType   = "PostgreSQL"
+	passwordAuthType = "password"
+	databaseType     = "database"
+)
+
+// AddPostgresDBCredential creates a new postgres db credential
+func (c *Client) AddPostgresDBCredential(credName, username, password, description, dbName, port string) (*Credential, error) {
+	newPostgresDBCredential := DBCredentialUpload{
+		BaseInfo: BaseInfo{
+			Name:        credName,
+			Description: description,
+		},
+		Type:     databaseType,
+		AuthType: passwordAuthType,
+		Login:    username,
+		Password: password,
+		SID:      dbName,
+		DBType:   postgresDBType,
+		Port:     port,
+	}
+
+	resp := &Credential{}
+	if _, err := c.postResource(credentialEndpoint, newPostgresDBCredential, resp); err != nil {
+		return nil, fmt.Errorf("failed to create postgres db credential: %w", err)
+	}
+
+	return resp, nil
+}
+
+// AddSSHCertificateCredential does the following:
+// 1. takes a public key and private key as strings and uploads those to tenable.sc
+// 2. for both private and public keys it stores the file name in PublicKey and PrivateKey in SSHCertificateCredentialUpload
+// 3. post the cred to tenable.sc and return the object
+func (c *Client) AddSSHCertificateCredential(publicKey, privateKey string, sshCertCred SSHCertificateCredentialUpload) (*Credential, error) {
+	var err error
+	sshCertCred.PrivateKey, err = c.handleSSHCertCredFileUpload(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to upload private key credential for credential name %s: %w", sshCertCred.Name, err)
+	}
+
+	sshCertCred.PublicKey, err = c.handleSSHCertCredFileUpload(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to upload public key credential for credential name %s: %w", sshCertCred.Name, err)
+	}
+
+	resp := &Credential{}
+	if _, err := c.postResource(credentialEndpoint, sshCertCred, resp); err != nil {
+		return nil, fmt.Errorf("failed to create ssh cert credential: %w", err)
+	}
+
+	return resp, nil
+}
+
+// UpdateSSHCertificateCredential does the following:
+// 1. takes a public key and private key as strings and uploads those to tenable.sc
+// 2. for both private and public keys it stores the file name in PublicKey and PrivateKey in SSHCertificateCredentialUpload
+// 3. patches the cred to tenable.sc and return the object
+func (c *Client) UpdateSSHCertificateCredential(publicKey, privateKey string, sshCertCred SSHCertificateCredentialUpload) (*Credential, error) {
+	var err error
+	sshCertCred.PrivateKey, err = c.handleSSHCertCredFileUpload(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to upload private key credential for credential name %s: %w", sshCertCred.Name, err)
+	}
+
+	sshCertCred.PublicKey, err = c.handleSSHCertCredFileUpload(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to upload public key credential for credential name %s: %w", sshCertCred.Name, err)
+	}
+
+	resp := &Credential{}
+	if _, err := c.patchResourceWithID(credentialEndpoint, sshCertCred, resp); err != nil {
+		return nil, fmt.Errorf("failed to update ssh cert credential: %w", err)
 	}
 
 	return resp, nil

--- a/vendor/github.com/palantir/tenablesc-client/tenablesc/report.go
+++ b/vendor/github.com/palantir/tenablesc-client/tenablesc/report.go
@@ -1,0 +1,70 @@
+package tenablesc
+
+import (
+	"fmt"
+)
+
+const reportEndpoint = "/report"
+
+// Report represents request/response structure from https://docs.tenable.com/tenablesc/api/Report.htm
+type Report struct {
+	BaseInfo
+	ReportDefinitionID string              `json:"reportDefinitionID"`
+	JobID              string              `json:"jobID"`
+	Type               string              `json:"type"`
+	Status             string              `json:"status"`
+	Running            string              `json:"running"`
+	ErrorDetails       string              `json:"errorDetails"`
+	TotalSteps         string              `json:"totalSteps"`
+	CompletedSteps     string              `json:"completedSteps"`
+	StartTime          UnixEpochStringTime `json:"startTime"`
+	FinishTime         UnixEpochStringTime `json:"finishTime"`
+	OwnerGID           string              `json:"ownerGID"`
+	PubSites           []BaseInfo          `json:"pubSites"`
+	Creator            UserInfo            `json:"creator"`
+	Owner              UserInfo            `json:"owner"`
+	OwnerGroup         BaseInfo            `json:"ownerGroup"`
+}
+
+type allReportsResponse struct {
+	Manageable []*Report `json:"manageable" tenable:"recurse"`
+	Usable     []*Report `json:"usable" tenable:"recurse"`
+}
+
+func (o allReportsResponse) allReportsToExternal() []*Report {
+	var spOut []*Report
+	spMap := make(map[ProbablyString]bool)
+
+	for _, o := range o.Usable {
+		spOut = append(spOut, o)
+		spMap[o.ID] = true
+	}
+	for _, o := range o.Manageable {
+		if _, exists := spMap[o.ID]; !exists {
+			spOut = append(spOut, o)
+			spMap[o.ID] = true
+		}
+	}
+
+	return spOut
+}
+
+func (c *Client) GetAllReports() ([]*Report, error) {
+
+	var allReports allReportsResponse
+	if _, err := c.getResource(reportEndpoint, &allReports); err != nil {
+		return nil, fmt.Errorf("failed to get reports: %w", err)
+	}
+
+	return allReports.allReportsToExternal(), nil
+}
+
+func (c *Client) GetReport(id string) (*Report, error) {
+	resp := &Report{}
+
+	if _, err := c.getResource(fmt.Sprintf("%s/%s", reportEndpoint, id), resp); err != nil {
+		return nil, fmt.Errorf("failed to get report id %s: %w", id, err)
+	}
+
+	return resp, nil
+}

--- a/vendor/github.com/palantir/tenablesc-client/tenablesc/report_definition.go
+++ b/vendor/github.com/palantir/tenablesc-client/tenablesc/report_definition.go
@@ -1,0 +1,44 @@
+package tenablesc
+
+import (
+	"fmt"
+)
+
+const reportDefinitionEndpoint = "/reportDefinition"
+
+// ReportDefinitionBase represents the base request/response structure from https://docs.tenable.com/tenablesc/api/Report-Definition.htm
+type ReportDefinitionBase struct {
+	BaseInfo
+}
+
+type allReportDefinitionsResponse struct {
+	Manageable []*ReportDefinitionBase `json:"manageable" tenable:"recurse"`
+	Usable     []*ReportDefinitionBase `json:"usable" tenable:"recurse"`
+}
+
+func (o allReportDefinitionsResponse) allReportDefinitionsToExternal() []*ReportDefinitionBase {
+	var spOut []*ReportDefinitionBase
+	spMap := make(map[ProbablyString]bool)
+
+	for _, o := range o.Usable {
+		spOut = append(spOut, o)
+		spMap[o.ID] = true
+	}
+	for _, o := range o.Manageable {
+		if _, exists := spMap[o.ID]; !exists {
+			spOut = append(spOut, o)
+			spMap[o.ID] = true
+		}
+	}
+
+	return spOut
+}
+
+func (c *Client) GetAllReportDefinitions() ([]*ReportDefinitionBase, error) {
+	var allReportDefinitions *allReportDefinitionsResponse
+	if _, err := c.getResource(reportDefinitionEndpoint, &allReportDefinitions); err != nil {
+		return nil, fmt.Errorf("failed to get report definitions: %w", err)
+	}
+
+	return allReportDefinitions.allReportDefinitionsToExternal(), nil
+}

--- a/vendor/github.com/palantir/tenablesc-client/tenablesc/scan.go
+++ b/vendor/github.com/palantir/tenablesc-client/tenablesc/scan.go
@@ -33,7 +33,7 @@ type Scan struct {
 	Reports              []ScanReports  `json:"reports,omitempty"`
 	RolloverType         string         `json:"rolloverType,omitempty"`
 	Schedule             *ScanSchedule  `json:"schedule,omitempty"`
-	ScanningVirtualHosts FakeBool       `json:"ScanningVirtualHosts,omitempty"`
+	ScanningVirtualHosts FakeBool       `json:"scanningVirtualHosts,omitempty"`
 	Status               string         `json:"status,omitempty"`
 	TimeoutAction        string         `json:"timeoutAction,omitempty"`
 	Type                 string         `json:"type,omitempty"`
@@ -60,6 +60,24 @@ type ScanSchedule struct {
 type ScanDependentSchedule struct {
 	BaseInfo
 	Status string `json:"status,omitempty"`
+}
+
+type ScanStartResult struct {
+	ScanID     string `json:"scanID"`
+	ScanResult struct {
+		BaseInfo
+		InitiatorID    int    `json:"initiatorID"`
+		OwnerID        string `json:"ownerID"`
+		ScanID         string `json:"scanID"`
+		ResultsSyncID  int    `json:"resultsSyncID"`
+		JobID          string `json:"jobID"`
+		RepositoryID   string `json:"repositoryID"`
+		Details        string `json:"details"`
+		Status         string `json:"status"`
+		DownloadFormat string `json:"downloadFormat"`
+		DataFormat     string `json:"dataFormat"`
+		ResultType     string `json:"resultType"`
+	} `json:"scanResult"`
 }
 
 type orgScanResponse struct {
@@ -109,6 +127,16 @@ func (c *Client) CreateScan(s *Scan) (*Scan, error) {
 
 	return resp, nil
 
+}
+
+func (c *Client) StartScan(id string) (*ScanStartResult, error) {
+	resp := &ScanStartResult{}
+
+	if _, err := c.postResource(fmt.Sprintf("%s/%s/launch", scanEndpoint, id), nil, resp); err != nil {
+		return nil, fmt.Errorf("failed to start scan id %s: %w", id, err)
+	}
+
+	return resp, nil
 }
 
 func (c *Client) GetScan(id string) (*Scan, error) {

--- a/vendor/github.com/palantir/tenablesc-client/tenablesc/scanpolicy.go
+++ b/vendor/github.com/palantir/tenablesc-client/tenablesc/scanpolicy.go
@@ -28,6 +28,8 @@ type ScanPolicyFamilies struct {
 	ID      string     `json:"id"`
 	Name    string     `json:"name,omitempty"`
 	Count   string     `json:"count,omitempty"`
+	State   string     `json:"state,omitempty"`
+	Type    string     `json:"type,omitempty"`
 	Plugins []BaseInfo `json:"plugins,omitempty"`
 }
 

--- a/vendor/github.com/palantir/tenablesc-client/tenablesc/scanresult.go
+++ b/vendor/github.com/palantir/tenablesc-client/tenablesc/scanresult.go
@@ -102,6 +102,25 @@ func (c *Client) GetScanResult(id string) (*ScanResult, error) {
 	return &resp, nil
 }
 
+func (c *Client) DeleteScanResult(id string) error {
+	if _, err := c.deleteResource(fmt.Sprintf("%s/%s", scanResultEndpoint, id), nil, nil); err != nil {
+		return fmt.Errorf("unable to delete scan result with id %s: %w", id, err)
+	}
+
+	return nil
+}
+
+// StopScanResult Stops the Scan Result associated with {id}.
+// NOTE: This endpoint is not applicable for Agent Sync Results.
+// ref: https://docs.tenable.com/tenablesc/api/Scan-Result.htm#ScanResultRESTReference-/scanResult/{id}/stop
+func (c *Client) StopScanResult(id string) error {
+	if _, err := c.postResource(fmt.Sprintf("%s/%s/stop", scanResultEndpoint, id), nil, nil); err != nil {
+		return fmt.Errorf("unable to stop scan result with id %s: %w", id, err)
+	}
+
+	return nil
+}
+
 func (c *Client) DownloadScanResult(id string) ([]byte, error) {
 
 	possiblyZippedStream, err := c.internalDownloadScanResult(id)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,8 +199,8 @@ github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.1.0
 ## explicit; go 1.13
 github.com/oklog/run
-# github.com/palantir/tenablesc-client v0.2.0
-## explicit; go 1.18
+# github.com/palantir/tenablesc-client v0.10.0
+## explicit; go 1.19
 github.com/palantir/tenablesc-client/tenablesc
 # github.com/posener/complete v1.2.3
 ## explicit; go 1.13


### PR DESCRIPTION
## Before this PR
Provider fails to manage scan policies for Tenable SC6.x appliances.
```
tenablesc_scan_policy….: Modifying... [id=…….]
╷
│ Error: failed to update scan policy: Policy Families list is malformed for Family #….. State must be set.
│ , error code 146
│ 
│   with tenablesc_scan_policy.vulnerability_scan,
│   on ……tf line 64, in resource "tenablesc_scan_policy" “….”:
│   64: resource "tenablesc_scan_policy" “…..” {
```
## After this PR
Allow configuring plugin family's state for Scan policy resources.

## Possible downsides?
None
