### PR TITLE
use unlimited as default max_scan_time

### DIFF
--- a/changelog/@unreleased/pr-170.v2.yml
+++ b/changelog/@unreleased/pr-170.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: use unlimited as default max_scan_time
+  links:
+  - https://github.com/palantir/terraform-provider-tenablesc/pull/170

--- a/internal/provider/resource_scan.go
+++ b/internal/provider/resource_scan.go
@@ -71,7 +71,7 @@ func ResourceScan() *schema.Resource {
 			"max_scan_time": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "3600",
+				Default:  "unlimited",
 			},
 			"inactivity_timeout": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
### Changes:

Set `unlimited` as the default value for `max_scan_time`. This default aligns with the Tenable.SC API documentation.
https://docs.tenable.com/security-center/best-practices/api/Content/PDF/Tenablesc_API_BestPracticesGuide.pdf