### PR TITLE
use clean flag for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
Resolving the following error during release
https://goreleaser.com/deprecations/#-rm-dist
```
/opt/hostedtoolcache/goreleaser-action/2.2.0/x64/goreleaser release --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.2.0/x64/goreleaser' failed with exit code 1
```

