### PR TITLE
Resolving Goreleaser errors

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,4 +58,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@
 #  hooks:
 #    # this is just an example and not a requirement for provider building/publishing
 #    - go mod tidy
+version: 2
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate


### PR DESCRIPTION
### Overview

Resolving the following errors:

*   `only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration`
* ` line 61: field skip not found in type config.Changelog`
https://goreleaser.com/deprecations/#after_7


