### PR TITLE
Improvement: Handle case where no agent group exists

### DIFF
--- a/changelog/@unreleased/pr-211.v2.yml
+++ b/changelog/@unreleased/pr-211.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Handle case where no agent group exists
+  links:
+  - https://github.com/palantir/terraform-provider-tenablesc/pull/211

--- a/internal/provider/datasource_agent_groups.go
+++ b/internal/provider/datasource_agent_groups.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -57,6 +58,11 @@ func dataSourceAgentGroupsRead(ctx context.Context, d *schema.ResourceData, m in
 
 	agentScannerID := d.Get("agent_scanner_id").(string)
 	agentGroups, err := sc.GetAgentGroupsForScanner(agentScannerID)
+	errors.Is(err, tenablesc.NotFoundError{})
+	nfe := tenablesc.NotFoundError{}
+	if errors.As(err, &nfe) {
+		return nil
+	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to get agent groups for scanner %s: %w", agentScannerID, err))
 	}


### PR DESCRIPTION
# Summary
- There are cases where we want to define terraform to be run in different environments which may or may not have agent groups.