### PR TITLE
Support Multi auditfile scan policy

### DIFF
--- a/changelog/@unreleased/pr-270.v2.yml
+++ b/changelog/@unreleased/pr-270.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Support Multi auditfile scan policy
+  links:
+  - https://github.com/palantir/terraform-provider-tenablesc/pull/270

--- a/docs/resources/scan_policy.md
+++ b/docs/resources/scan_policy.md
@@ -52,7 +52,8 @@ resource "sc_scan_policy" "vulnerability_scan_port22" {
 
 ### Optional
 
-- `audit_file_id` (String) Audit File ID
+- `audit_file_id` (String, Deprecated) Audit File ID
+- `audit_file_ids` (Set of String) Audit File IDs
 - `description` (String) Scan Policy description
 - `families` (Set of String) Plugin Families to include in scan
 - `families_state` (String) Plugin Families state to include in scan. Must be set to 'unlocked' for Tenable.SC 6x

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -137,13 +137,13 @@ func diffSuppressNormalizedIPSet(k, oldValue, newValue string, d *schema.Resourc
 
 	oldSet, err := buildIPSetForTenableFormat(oldValue)
 	if err != nil {
-		Logf(logDebug, err.Error())
+		Logf(logDebug, "%s", err.Error())
 		return false
 	}
 
 	newSet, err := buildIPSetForTenableFormat(newValue)
 	if err != nil {
-		Logf(logDebug, err.Error())
+		Logf(logDebug, "%s", err.Error())
 		return false
 	}
 

--- a/internal/provider/datasource_credential.go
+++ b/internal/provider/datasource_credential.go
@@ -57,5 +57,5 @@ func dataSourceCredentialRead(ctx context.Context, d *schema.ResourceData, m int
 		}
 	}
 
-	return diag.Errorf("No credential found with name='" + credentialName + "'")
+	return diag.Errorf("No credential found with name='%s'", credentialName)
 }

--- a/internal/provider/descriptions.go
+++ b/internal/provider/descriptions.go
@@ -87,6 +87,7 @@ Requires Administrator (org=0) credentials.`
 	descriptionOrganizationID          = `Organization ID`
 	descriptionScanPolicyTemplateID    = `Scan Policy Template ID`
 	descriptionAuditFileID             = `Audit File ID`
+	descriptionAuditFileIDs            = `Audit File IDs`
 	descriptionOrganizationScanZoneIDs = `Scan Zone IDs to be allowed to be used by organization`
 
 	// Miscellaneous

--- a/internal/provider/resource_repository_organization_association.go
+++ b/internal/provider/resource_repository_organization_association.go
@@ -178,7 +178,7 @@ func buildRepositoryOrganizationAssociationInputs(d *schema.ResourceData) (*tena
 		return nil, err
 
 	}
-	Logf(logDebug, fmt.Sprintf("built Repository Association: %s", repositoryAssociationBytes))
+	Logf(logDebug, "built Repository Association: %s", repositoryAssociationBytes)
 
 	return repositoryAssociation, nil
 }

--- a/internal/provider/resource_scan_policy.go
+++ b/internal/provider/resource_scan_policy.go
@@ -17,6 +17,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/palantir/tenablesc-client/tenablesc"

--- a/internal/provider/resource_scan_policy.go
+++ b/internal/provider/resource_scan_policy.go
@@ -54,10 +54,19 @@ func ResourceScanPolicy() *schema.Resource {
 				Required:    true,
 			},
 			"audit_file_id": {
-				Type:        schema.TypeString,
-				Description: descriptionAuditFileID,
-				Optional:    true,
-				Default:     "",
+				Type:          schema.TypeString,
+				Description:   descriptionAuditFileID,
+				Optional:      true,
+				Default:       "",
+				ConflictsWith: []string{"audit_file_ids"},
+				Deprecated:    "The 'audit_file_id' is deprecated. Use 'audit_file_ids'(set) instead.",
+			},
+			"audit_file_ids": {
+				Type:          schema.TypeSet,
+				Description:   descriptionAuditFileIDs,
+				Optional:      true,
+				ConflictsWith: []string{"audit_file_id"},
+				Elem:          &schema.Schema{Type: schema.TypeString},
 			},
 			"preferences": {
 				Type:        schema.TypeMap,

--- a/internal/provider/resource_scan_policy.go
+++ b/internal/provider/resource_scan_policy.go
@@ -17,7 +17,6 @@ package provider
 import (
 	"context"
 	"encoding/json"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/palantir/tenablesc-client/tenablesc"
@@ -152,10 +151,15 @@ func resourceScanPolicyRead(ctx context.Context, d *schema.ResourceData, m inter
 	}
 	d.Set("families", tfFamilies)
 
-	if len(policy.AuditFiles) > 0 {
-		d.Set("audit_file_id", policy.AuditFiles[0].ID)
+	var ids []string
+	for _, auditfile := range policy.AuditFiles {
+		ids = append(ids, string(auditfile.ID))
+	}
+
+	if _, ok := d.GetOk("audit_file_id"); ok {
+		d.Set("audit_file_id", ids[0])
 	} else {
-		d.Set("audit_file_id", "")
+		d.Set("audit_file_ids", ids)
 	}
 
 	d.SetId(string(policy.ID))
@@ -237,7 +241,6 @@ func buildScanPolicyInputs(d *schema.ResourceData) (*tenablesc.ScanPolicy, error
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
 	policyTemplateID := d.Get("policy_template_id").(string)
-	auditFileID := d.Get("audit_file_id").(string)
 	families := d.Get("families").(*schema.Set).List()
 	familiesState := d.Get("families_state").(string)
 	tag := d.Get("tag").(string)
@@ -289,9 +292,16 @@ func buildScanPolicyInputs(d *schema.ResourceData) (*tenablesc.ScanPolicy, error
 		spInput.Families = famInput
 	}
 
-	if auditFileID != "" {
-		spInput.AuditFiles = []tenablesc.BaseInfo{{ID: tenablesc.ProbablyString(auditFileID)}}
+	var auditFiles []tenablesc.BaseInfo
+	if v, ok := d.GetOk("audit_file_id"); ok {
+		auditFiles = append(auditFiles, tenablesc.BaseInfo{ID: tenablesc.ProbablyString(v.(string))})
+	} else if v, ok := d.GetOk("audit_file_ids"); ok {
+		for _, ID := range v.(*schema.Set).List() {
+			auditFiles = append(auditFiles, tenablesc.BaseInfo{ID: tenablesc.ProbablyString(ID.(string))})
+		}
 	}
+
+	spInput.AuditFiles = auditFiles
 
 	return spInput, nil
 }


### PR DESCRIPTION
### Overview

This PR extends the resource_scan_policy to support configuring multiple audit files while maintaining backward compatibility with existing single audit file configurations.

### Changes
* Add `audit_file_ids` field for multiple audit file support.
* Ensure `audit_file_id` remains for backward compatibility.
* Use printf formatter style for logging.